### PR TITLE
lint to pass tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,13 +25,13 @@ find_package(rosidl_default_generators REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/RslidarPacket.msg"
   DEPENDENCIES builtin_interfaces std_msgs
- )
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights
   # uncomment the line when a copyright and license is not present in all source files
-  #set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_copyright_FOUND TRUE)
   # the following line skips cpplint (only works in a git repo)
   # uncomment the line when this package is not in a git repo
   #set(ament_cmake_cpplint_FOUND TRUE)

--- a/ros1/CMakeLists.txt
+++ b/ros1/CMakeLists.txt
@@ -23,19 +23,19 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   sensor_msgs
   message_generation
-  )
+)
 
 add_message_files(FILES
   RslidarPacket.msg
-  )
+)
 
-generate_messages(DEPENDENCIES 
+generate_messages(DEPENDENCIES
   std_msgs
   sensor_msgs
-  )
+)
 
-catkin_package(CATKIN_DEPENDS 
-  std_msgs 
+catkin_package(CATKIN_DEPENDS
+  std_msgs
   sensor_msgs
   message_runtime
-  )
+)

--- a/ros2/CMakeLists.txt
+++ b/ros2/CMakeLists.txt
@@ -25,16 +25,16 @@ find_package(rosidl_default_generators REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/RslidarPacket.msg"
   DEPENDENCIES builtin_interfaces std_msgs
- )
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights
   # uncomment the line when a copyright and license is not present in all source files
-  #set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_copyright_FOUND TRUE)
   # the following line skips cpplint (only works in a git repo)
   # uncomment the line when this package is not in a git repo
-  #set(ament_cmake_cpplint_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()
 


### PR DESCRIPTION
This PR lints the `CMakeFiles.txt`s so that the tests defined [here](https://github.com/RoboSense-LiDAR/rslidar_msg/blob/fe8a95cb242bd294cc3d5e3422f2093fb49a56ee/package.xml#L15) pass successfully. 

The PR also disables copyright linting since the `LICENSE.md` and `CONTRIBUTION.md` are not present.

After this, `colcon build && colcon test` passes successfully. 